### PR TITLE
Use the new interface for matplotlib colormaps.

### DIFF
--- a/src/convert_nanoscope/image.py
+++ b/src/convert_nanoscope/image.py
@@ -92,10 +92,8 @@ def proc_spm(
     )
     # create pillow image from array
     if cmap is not None:
-        import matplotlib.cm as cm
-
         img = Image.fromarray(
-            (cm.get_cmap(cmap, lut=256)(iv)[:, :, :3] * 255).astype(np.uint8),
+            (matplotlib.colormaps[cmap](iv)[:, :, :3] * 255).astype(np.uint8),
             mode="RGB",
         )
     else:


### PR DESCRIPTION
[`get_cmap` is deprecated](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.7.0.html#deprecation-of-top-level-cmap-registration-and-access-functions-in-mpl-cm) since matplotlib 3.7.0.  This PR fixes `image.py` to work with the new dict interface.

The old `get_cmap` had a `lut` parameter, which `image.py` used to set to 256. This PR simply forgets about that since it seems to work for me, but I am not sure how general this fix is.